### PR TITLE
add `remove_widget_view` to `nglview_struct.render_html`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+0.2.1
+------
+
+Added
++++++
+* ``remove_widget_view`` option to ``nglview_struct.render_html`` to enable embedding of structure widgets in HTML without showing them twice.
+
 0.2.0
 ------
 

--- a/pdb_prot_align/__init__.py
+++ b/pdb_prot_align/__init__.py
@@ -9,5 +9,5 @@ Python interface to ``pdb_prot_align``.
 
 __author__ = '`the Bloom lab <https://research.fhcrc.org/bloom/en.html>`_'
 __email__ = 'jbloom@fredhutch.org'
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 __url__ = 'https://github.com/jbloomlab/pdb_prot_align'

--- a/pdb_prot_align/nglview_struct.py
+++ b/pdb_prot_align/nglview_struct.py
@@ -120,6 +120,7 @@ def render_html(view,
                 *,
                 html_file=None,
                 orientation=None,
+                remove_widget_view=False,
                 ):
     """Render widget to HTML display.
 
@@ -134,6 +135,10 @@ def render_html(view,
         https://github.com/dwhswenson/contact_map/pull/62#issuecomment-583788933
         You can get the desired orientation by manually manipulating the widget
         in a Jupyter notebook and then calling `view._get_orientation`.
+    remove_widget_view : bool
+        Remove the widget view lines, so the HTML just gives the widget state.
+        Helpful if you want to embed widgets in HTML rendering without showing
+        another time.
 
     Returns
     -------
@@ -154,6 +159,14 @@ def render_html(view,
                            '"_camera_orientation": [' +
                            ', '.join(map(str, orientation)) + ']',
                            html_text)
+
+    if remove_widget_view:
+        widget_view_regex = (
+                r'<script type="application/vnd\.jupyter\.widget\-view\+json">'
+                r'\n.*?\n'
+                '</script>'
+                )
+        html_text = re.sub(widget_view_regex, '', html_text)
 
     if html_file:
         if os.path.splitext(html_file)[1] != '.html':


### PR DESCRIPTION
Enables embedding of structure widgets in HTML without showing them twice. Used this to fix `nglview` example to avoid widget duplication.

Incremented version to 0.2.1.